### PR TITLE
docs: add remove untagged images

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,12 @@ docker rmi $(docker images -f dangling=true -q)
 docker rmi $(docker images -a -q)
 ```
 
+## Removing all untagged images
+
+```
+docker rmi -f $(docker images | grep "^<none>" | awk "{print $3}")
+```
+
 ## Stopping & Removing all Containers
 
 ```


### PR DESCRIPTION
This PR will add docker command to remove all untagged images by make use of `awk` command.

It is useful when we want to clean up all docker images  with tag `<none>`. 