### PR TITLE
docs: fix `docker search` command with options not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker search nginx
 ```
 
 ```
-docker search nginx --stars=3 --no-trunc busybox
+docker search --filter stars=3 --no-trunc nginx
 ```
 
 ## Pulling an Image


### PR DESCRIPTION
## c14310f docs: fix `docker search` command with options not working

The second command of [Searching an image section](https://git.io/vd7q6)
does not work as it's supposed to have exactly 1 argument, while 2
arguments are given in the example; see the output below:

```
$ docker search nginx --stars=3 --no-trunc busybox
Flag --stars has been deprecated, use --filter=stars=3 instead
"docker search" requires exactly 1 argument.
See 'docker search --help'.

Usage:  docker search [OPTIONS] TERM

Search the Docker Hub for images
```

Also, the above command output suggests that the `--stars` command has
been deprecated (see: https://goo.gl/p9JukR). Now we are encouraged use
either:

1. `docker search --filter stars=3 TERM`
2. `docker search --filter=stars=3 TERM`
3. `docker search --filter "stars=3" TERM` or single quoted `'stars=3'`

The 1st option `--filter stars=3` has been picked for this commit even
though the error message suggested that the user should use the 2nd
option `--filter-stars=3`. This is only because some usage examples
found in the `docker search` section of Docker Docs described in the 1st
filter-by-stars style (see: https://goo.gl/XHHYYW).

---

### Message from the collaborator

Please review my commit and if necessary, rectify as appropriate.

Thank you!

sho